### PR TITLE
feat: customize author and maintainer info

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -2,5 +2,7 @@
     "project_name": "My Awesome Project",
     "project_description": "Initial setup for {{ cookiecutter.project_name }}.",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
-    "package_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}"
+    "package_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+    "username": "VictorF13",
+    "email": "victorabreuf13@gmail.com"
 }

--- a/{{cookiecutter.project_slug}}/LICENSE
+++ b/{{cookiecutter.project_slug}}/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) {% now 'utc', '%Y' %} Victor Abreu
+Copyright (c) {% now 'utc', '%Y' %} {{ cookiecutter.username }} <{{ cookiecutter.email }}>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 description = "{{ cookiecutter.project_description }}"
 readme = "README.md"
 authors = [
-    { name = "VictorF13", email = "victorabreuf13@gmail.com" }
+    { name = "{{ cookiecutter.username }}", email = "{{ cookiecutter.email }}" }
 ]
 maintainers = [
-    { name = "VictorF13", email = "victorabreuf13@gmail.com" }
+    { name = "{{ cookiecutter.username }}", email = "{{ cookiecutter.email }}" }
 ]
 requires-python = ">=3.12"
 license = { text = "MIT" }


### PR DESCRIPTION
## Summary
- prompt for `username` and single `email`
- apply contact info to `pyproject.toml` authors/maintainers and `LICENSE`
- revert README to prior state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acf83e87c8832eb12ad8b49d71ff6c