### PR TITLE
Use basedpyright for type checking

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -5,7 +5,7 @@ set -e
 
 # Add development dependencies
 uv add --dev ruff
-uv add --dev ty
+uv add --dev basedpyright
 uv add --dev pre-commit
 
 # Initialize git and install pre-commit hooks

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
     - id: ruff-check
       args: [ --fix ]
     - id: ruff-format
+- repo: https://github.com/DetachHead/basedpyright-pre-commit-mirror
+  rev: v1.13.0
+  hooks:
+    - id: basedpyright
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.8.0
   hooks:
@@ -15,3 +19,4 @@ repos:
       name: dev dependencies
       args: [--only-group, dev, --output-file, requirements-dev.txt]
     - id: uv-lock
+

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -20,3 +20,8 @@ build-backend = "hatchling.build"
 [tool.ruff]
 lint.extend-select = ["ALL"]
 lint.ignore = ["PLR0913", "D203", "D213", "COM812"]
+
+[tool.basedpyright]
+include = ["src"]
+typeCheckingMode = "recommended"
+


### PR DESCRIPTION
## Summary
- replace ty with basedpyright in post-generation script
- configure basedpyright in pyproject
- run basedpyright via pre-commit hook

## Testing
- `pip install pre-commit` *(failed: Could not connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_68b724b299ec832e8b2604b05fb5c400