### PR TITLE
Use prek for git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ use this template myself whenever starting a new library.
 ## Features
 
 - Pre-generation hook verifies `uv`, `git`, and Python 3.12+.
-- Modern `pyproject.toml` configuration with `uv` and pre-commit defaults.
+- Modern `pyproject.toml` configuration with `uv` and prek defaults.
 - Personal scaffold used by [VictorF13](https://github.com/VictorF13).
 
 ## Installation

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -6,17 +6,17 @@ set -e
 # Add development dependencies
 uv add --dev ruff
 uv add --dev basedpyright
-uv add --dev pre-commit
+uv add --dev prek
 
-# Initialize git and install pre-commit hooks
+# Initialize git and install prek hooks
 git init -b "main"
-uv run pre-commit install
-uv run pre-commit autoupdate
-uv run pre-commit install
+uv run prek install
+uv run prek autoupdate
+uv run prek install
 
 # Make initial commit
 git add .
-uv run pre-commit run --all-files
+uv run prek run --all-files
 git add .
 git commit -m "Initial commit"
 


### PR DESCRIPTION
## Summary
- replace pre-commit usage with the prek tool
- document prek defaults in README

## Testing
- `uvx prek run --all-files` *(fails: Failed to fetch `https://pypi.org/simple/prek/`)*

------
https://chatgpt.com/codex/tasks/task_e_68b728cab72c832e9408af99faed0276